### PR TITLE
Include timestamp when printing news item

### DIFF
--- a/informant
+++ b/informant
@@ -118,6 +118,7 @@ def pretty_print_item(item):
     replaced. """
     title = item.title
     body = item.summary
+    timestamp = item.published
     if not ARGV.get(RAW_OPT):
         body = body.replace('<p>', '\t')
         body = body.replace('</p>', '\n')
@@ -125,7 +126,7 @@ def pretty_print_item(item):
         body = body.replace('</code></pre>', '\n```\n')
         body = body.replace('<code>', '`')
         body = body.replace('</code>', '`')
-    print(title + '\n\n' + body)
+    print(title + '\n' + timestamp + '\n\n' + body)
 
 def check_cmd(feed):
     """ Run the check command. Check if there are any news items that are

--- a/informant
+++ b/informant
@@ -37,6 +37,8 @@ import sys
 import docopt
 import feedparser
 from dateutil import parser as date_parser
+import shutil
+import textwrap
 
 ARCH_NEWS = 'https://archlinux.org/feeds/news'
 FILE_DEFAULT = '/var/cache/informant.dat'
@@ -128,6 +130,28 @@ def pretty_print_item(item):
         body = body.replace('</code>', '`')
     print(title + '\n' + timestamp + '\n\n' + body)
 
+def format_list_item(entry, index):
+    """ Returns a formatted string with the entry's index number, title, and 
+    right-aligned timestamp. """
+    terminal_width = shutil.get_terminal_size().columns
+    heading = str(index) + ': ' + entry.title
+    padding = terminal_width - len(heading + entry.published)
+    wrap_width = terminal_width - len(entry.published)
+    if (len(heading) > wrap_width):
+        heading = textwrap.wrap(heading, wrap_width)
+        return (
+            heading[0] +
+            ' ' +
+            entry.published +
+            ''.join(heading[1:])
+        )
+    else:
+        return (
+            heading +
+            ' ' * (padding) +
+            entry.published
+        )
+
 def check_cmd(feed):
     """ Run the check command. Check if there are any news items that are
     unread. If there is only one unread item, print it out and mark it as read.
@@ -156,8 +180,7 @@ def list_cmd(feed):
     for entry in feed_list:
         if not ARGV.get(UNREAD_OPT) \
         or (ARGV.get(UNREAD_OPT) and not has_been_read(entry)):
-            print(index, end=': ')
-            print(entry.title)
+            print(format_list_item(entry, index))
             index += 1
 
 def read_cmd(feed):

--- a/informant
+++ b/informant
@@ -37,6 +37,8 @@ import sys
 import docopt
 import feedparser
 from dateutil import parser as date_parser
+import shutil
+import textwrap
 
 ARCH_NEWS = 'https://archlinux.org/feeds/news'
 FILE_DEFAULT = '/var/cache/informant.dat'
@@ -128,6 +130,21 @@ def pretty_print_item(item):
         body = body.replace('</code>', '`')
     print(title + '\n' + timestamp + '\n\n' + body)
 
+def format_list_item(entry, index):
+    """ Returns a formatted string with the entry's index number, title, and 
+    right-aligned timestamp. """
+    terminal_width = shutil.get_terminal_size().columns
+    wrap_width = terminal_width - len(entry.published) - 1
+    heading = str(index) + ': ' + entry.title
+    wrapped_heading = textwrap.wrap(heading, wrap_width)
+    padding = terminal_width - len(wrapped_heading[0] + entry.published)
+    return (
+        wrapped_heading[0] +
+        ' ' * (padding) +
+        entry.published +
+        '\n'.join(wrapped_heading[1:])
+    )
+
 def check_cmd(feed):
     """ Run the check command. Check if there are any news items that are
     unread. If there is only one unread item, print it out and mark it as read.
@@ -156,8 +173,7 @@ def list_cmd(feed):
     for entry in feed_list:
         if not ARGV.get(UNREAD_OPT) \
         or (ARGV.get(UNREAD_OPT) and not has_been_read(entry)):
-            print(index, end=': ')
-            print(entry.title)
+            print(format_list_item(entry, index))
             index += 1
 
 def read_cmd(feed):

--- a/informant
+++ b/informant
@@ -37,8 +37,6 @@ import sys
 import docopt
 import feedparser
 from dateutil import parser as date_parser
-import shutil
-import textwrap
 
 ARCH_NEWS = 'https://archlinux.org/feeds/news'
 FILE_DEFAULT = '/var/cache/informant.dat'
@@ -130,28 +128,6 @@ def pretty_print_item(item):
         body = body.replace('</code>', '`')
     print(title + '\n' + timestamp + '\n\n' + body)
 
-def format_list_item(entry, index):
-    """ Returns a formatted string with the entry's index number, title, and 
-    right-aligned timestamp. """
-    terminal_width = shutil.get_terminal_size().columns
-    heading = str(index) + ': ' + entry.title
-    padding = terminal_width - len(heading + entry.published)
-    wrap_width = terminal_width - len(entry.published)
-    if (len(heading) > wrap_width):
-        heading = textwrap.wrap(heading, wrap_width)
-        return (
-            heading[0] +
-            ' ' +
-            entry.published +
-            ''.join(heading[1:])
-        )
-    else:
-        return (
-            heading +
-            ' ' * (padding) +
-            entry.published
-        )
-
 def check_cmd(feed):
     """ Run the check command. Check if there are any news items that are
     unread. If there is only one unread item, print it out and mark it as read.
@@ -180,7 +156,8 @@ def list_cmd(feed):
     for entry in feed_list:
         if not ARGV.get(UNREAD_OPT) \
         or (ARGV.get(UNREAD_OPT) and not has_been_read(entry)):
-            print(format_list_item(entry, index))
+            print(index, end=': ')
+            print(entry.title)
             index += 1
 
 def read_cmd(feed):


### PR DESCRIPTION
This adds the date and time the news item was published to the output of the 'read' subcommand.