### PR TITLE
Add interactive mode to read subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ news items it will interrupt your pacman transaction.
 is given). There is also a '--reverse' option if you prefer to see them newest
 to oldest.
 
-`informant read` - will print a given news item and mark it as read. You must
-either specify a news item as either an index or a string matching the title, or
-include the '--all' option. If you want to use an index it must only be that
-shown when running `informant list` (without '--unread' or '--reverse').
+`informant read` - if given a news item, will print that item and mark it as read. 
+You must either specify a news item as either an index or a string matching the title.
+If you want to use an index it must only be that shown when running `informant list` 
+(without '--unread' or '--reverse'). If no item is given, will begin looping through
+all unread items, printing each one and marking them as read with a prompt to continue. 
+Passing the '--all' flag will mark all items as read without printing them.
 
 More options can be found by reading `informant --help`.
 

--- a/informant
+++ b/informant
@@ -5,7 +5,7 @@ informant - an Arch Linux News reader designed to also be used as a pacman hook
 Usage:
     informant [options] check
     informant [options] list [--reverse --unread]
-    informant [options] read (<item> | --all)
+    informant [options] read [<item> | --all]
 
 Commands:
     check - Check for unread news items, will exit with a positive return code
@@ -19,7 +19,10 @@ Commands:
 
     read  - Read the specified news item, <item> can be either an index or a
             full title. This will also save the item as 'read' so that future
-            calls to 'check' will no longer display it.
+            calls to 'check' will no longer display it. If no <item> is given,
+            will begin looping through all unread items, printing each one and
+            marking them as read with a prompt to continue. Passing the --all 
+            flag will mark all items as read without printing.
 
 Options:
     -d, --debug                 Print the command line arguments and don't make
@@ -182,17 +185,33 @@ def read_cmd(feed):
         for entry in feed.entries:
             mark_as_read(entry)
     else:
-        item = ARGV[ITEM_ARG]
-        try:
-            index = int(item)
-            entry = feed.entries[index]
-        except ValueError:
+        if ARGV[ITEM_ARG]:
+            try:
+                item = int(ARGV[ITEM_ARG])
+                entry = feed.entries[item]
+            except ValueError:
+                for entry in feed.entries:
+                    if entry.title == item:
+                        break
+                #NOTE: this will read the oldest unread item if no matches are found
+            pretty_print_item(entry)
+            mark_as_read(entry)
+        else:
+            unread_entries = list()
             for entry in feed.entries:
-                if entry.title == item:
-                    break
-            #NOTE: this will read the oldest unread item if no matches are found
-        pretty_print_item(entry)
-        mark_as_read(entry)
+                if not has_been_read(entry):
+                    unread_entries.append(entry)
+            for entry in unread_entries:
+                pretty_print_item(entry)
+                mark_as_read(entry)
+                if entry is not unread_entries[-1]:
+                    read_next = input('Read next item? (Y/n) ')
+                    if read_next == 'n' or read_next == 'N':
+                        break
+                    else:
+                        continue
+                else:
+                    print('No more unread items')
 
 def run():
     """ The main function.


### PR DESCRIPTION
In absense of any parameters, read subcommand will now interactively
print unread news items.

This is an attempt at resolving #5. If you'd like this to behave a little differently, I'd be happy to make adjustments.