### PR TITLE
Handle feedparser errors

### DIFF
--- a/informant
+++ b/informant
@@ -286,7 +286,7 @@ def run():
     else:
         feed = feedparser.parse(ARCH_NEWS)
         if feed.bozo:
-            print(feed.bozo_exception)
+            err_print(feed.bozo_exception)
             sys.exit(255)
         write_cache(feed)
 

--- a/informant
+++ b/informant
@@ -285,6 +285,9 @@ def run():
         feed = CACHE['feed']
     else:
         feed = feedparser.parse(ARCH_NEWS)
+        if feed.bozo:
+            print(feed.bozo_exception)
+            sys.exit(255)
         write_cache(feed)
 
     if ARGV.get(CHECK_CMD):


### PR DESCRIPTION
In the event of an error or malformed feed, feedparser will set a `bozo` flag with an accompanying `bozo_exception` field describing the error. See here https://pythonhosted.org/feedparser/bozo.html This commit checks the `bozo` flag and if it is set, prints the error and aborts the script.