### PR TITLE
Fix with activate virtualenv

### DIFF
--- a/informant
+++ b/informant
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """
 informant - an Arch Linux News reader designed to also be used as a pacman hook
 


### PR DESCRIPTION
Sometimes I run pacman with virtual environment activated, and it will fail the transaction if this project doesn't include the requirements.
Thus, pinning to system python3 should be a good idea.