### PR TITLE
Fixing the hook path in both README.md and the man page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ transaction (even after trying to read the news) you should be able to `pacman
 
 informant installs its hook to `/usr/share/libalpm/hooks/` so you should also be
 able to override the pacman hook by placing a new hook in
-`/etc/pacman.d/hooks/informant.hook` or disable it by placing a symlink to
+`/etc/pacman.d/hooks/00-informant.hook` or disable it by placing a symlink to
 `/dev/null` in that location (e.g. `ln -s /dev/null
-/etc/pacman.d/hooks/informant.hook`).
+/etc/pacman.d/hooks/00-informant.hook`).
 
 More information on pacman hooks can be found in `man alpm-hooks`.
 

--- a/man/informant.1
+++ b/man/informant.1
@@ -84,7 +84,7 @@ file.
 .B NOTE
 Changing the file will not change the file read by the pacman hook because the
 pacman hook runs as root, if you want to change that you can do so manually by
-editing /usr/share/libalpm/hooks/informant.hook
+editing /usr/share/libalpm/hooks/00-informant.hook
 
 .TP
 .BR \-\-no\-cache


### PR DESCRIPTION
The hook file is prefixed with `00-` when it is installed (see [AUR PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=informant) line 18).
This change fixes the file paths in the documentation accordingly.