### PR TITLE
Uncapitalize 'Cache-Control' header name

### DIFF
--- a/informant
+++ b/informant
@@ -305,7 +305,7 @@ def write_cache(feed):
         return
     CACHE['feed'] = feed
     CACHE['last-request'] = str(time.time())
-    CACHE['max-age'] = feed.headers['Cache-Control'].split('=')[1]
+    CACHE['max-age'] = feed.headers['cache-control'].split('=')[1]
     save_datfile()
 
 def run():


### PR DESCRIPTION
The `Cache-Control: max-age` header sent by the server seems to have changed names to `cache-control`, which breaks `informant check`. This patch fixes the issue.