### PR TITLE
Fix possible unbound variables

### DIFF
--- a/informant
+++ b/informant
@@ -262,16 +262,19 @@ def read_cmd(feed):
     else:
         if ARGV[ITEM_ARG]:
             item = ARGV[ITEM_ARG]
-            try:
-                item = int(item)
-                entry = feed.entries[item]
-            except ValueError:
+            if item.isdigit():
+                entry = feed.entries[int(item)]
+                pretty_print_item(entry)
+                mark_as_read(entry)
+            else:
                 for entry in feed.entries:
                     if entry.title == item:
+                        pretty_print_item(entry)
+                        mark_as_read(entry)
                         break
-                #NOTE: this will read the oldest unread item if no matches are found
-            pretty_print_item(entry)
-            mark_as_read(entry)
+                else:
+                    err_print('Could not find ' + item + ' in newsfeed')
+                    sys.exit(255)
         else:
             unread_entries = list()
             for entry in feed.entries:

--- a/informant
+++ b/informant
@@ -261,8 +261,9 @@ def read_cmd(feed):
             mark_as_read(entry)
     else:
         if ARGV[ITEM_ARG]:
+            item = ARGV[ITEM_ARG]
             try:
-                item = int(ARGV[ITEM_ARG])
+                item = int(item)
                 entry = feed.entries[item]
             except ValueError:
                 for entry in feed.entries:

--- a/informant
+++ b/informant
@@ -98,6 +98,8 @@ def prompt_yes_no(question, default):
         options = '(Y/n): '
     elif default.lower() in ('n', 'no'):
         options = '(y/N): '
+    else:
+        raise ValueError('default must be "y", "yes", "n", or "no"')
 
     response = input(' '.join((question, options))).lower()
     while response not in ('y', 'yes', 'n', 'no', ''):


### PR DESCRIPTION
A few things going on in this branch:
Currently `informant` crashes with an `UnboundLocalError` when the user provides a title to the `read` command. That's my fault from #9 The first commit fixes this by just moving the assignment of `item` to outside the conditional block. 

But I only encounted this error because my linter was warning me about a possible unbound variable, and I had forgotten that the user could even specify a title to read. So as I was reading this block of code I was having trouble understanding what it was even supposed to be doing or why. The second commit rewrites it to be more clear and obvious (IMO). 

The third commit prevents a possible `UnboundLocalError` in `prompt_yes_no` in the event that `default` isn't what we expected.