### PR TITLE
fix a typo in feed.py

### DIFF
--- a/informant/feed.py
+++ b/informant/feed.py
@@ -72,7 +72,7 @@ class Feed:
                 session = CacheControl(requests.Session(), cache=FileCache(cachefile, filemode=0o0664, dirmode=0o0775))
                 feed = feedparser.parse(session.get(self.url).content)
             except Exception as e:
-                ui.err_print('Unable to read cache informantion: {}'.format(e))
+                ui.err_print('Unable to read cache information: {}'.format(e))
                 feed = feedparser.parse(self.url)
         else:
             feed = feedparser.parse(self.url)


### PR DESCRIPTION
Hey there :wave: 

I'm not sure if you're doing something clever here (and please feel free to close this if you are), but the error for when informant can't reach the network is misspelled:

> Unable to read cache informa**n**tion: HTTPSConnectionPool(host='archlinux.org', port=443): Max retries exceeded with url: /feeds/news/ ... (etc etc)

It's `information` (no `n`). Again, if this is a clever play on informant + information, then my bad lmao, just thought I'd let you know.

Thanks for a very useful tool!