### PR TITLE
Remove space before ... in hook

### DIFF
--- a/informant.hook
+++ b/informant.hook
@@ -6,7 +6,7 @@ Target = *
 Target = !informant
 
 [Action]
-Description = Checking Arch News with Informant ...
+Description = Checking Arch News with Informant...
 When = PreTransaction
 Exec = /usr/bin/informant check
 AbortOnFail


### PR DESCRIPTION
Hi! First of all, thanks for doing Informant; it's great software.

I propose to remove the blank space before `...` in the Pacman hook, changing `Checking Arch News with Informant ...` to `Checking Arch News with Informant...`. I believe this convention is more used.

