### PR TITLE
feat: support sending the news item to a pager for enhanced formatting.

### DIFF
--- a/informant/config.py
+++ b/informant/config.py
@@ -14,6 +14,7 @@ CFILE_OPT = '--config'
 NOCACHE_OPT = '--no-cache'
 CLRCACHE_OPT = '--clear-cache'
 CLRREAD_OPT = '--clear-readlist'
+PAGER_OPT = '--pager'
 
 FILE_DEFAULT = '/var/lib/informant.dat' # readlist save file
 CACHE_DEFAULT = '/var/cache/informant' # http caching
@@ -90,8 +91,9 @@ class InformantConfig(metaclass=Singleton):
         self.config = config
 
     def get_pager(self):
-        return self.config.get('pager', PAGER_DEFAULT) if self.config else PAGER_DEFAULT
-
+        if self.argv.get(PAGER_OPT):
+            return self.argv.get(PAGER_OPT)
+        return PAGER_DEFAULT
 
     def read_config(self):
         self.config = {}

--- a/informant/config.py
+++ b/informant/config.py
@@ -18,6 +18,7 @@ CLRREAD_OPT = '--clear-readlist'
 FILE_DEFAULT = '/var/lib/informant.dat' # readlist save file
 CACHE_DEFAULT = '/var/cache/informant' # http caching
 CONFIG_BASE = 'informantrc.json' # user config
+PAGER_DEFAULT = os.environ.get('INFORMANT_PAGER', default=None)
 
 class Singleton(type):
     """ A Singleton class to be used as a base """
@@ -87,6 +88,10 @@ class InformantConfig(metaclass=Singleton):
 
     def set_config(self, config):
         self.config = config
+
+    def get_pager(self):
+        return self.config.get('pager', PAGER_DEFAULT) if self.config else PAGER_DEFAULT
+
 
     def read_config(self):
         self.config = {}

--- a/informant/informant.py
+++ b/informant/informant.py
@@ -32,6 +32,7 @@ Options:
                                     markup
     -f <file>, --file=<file>        Use <file> as the save location for read
                                     items
+    -p <pager>, --pager=<pager>     Use <pager> as the pager to display the items
     --no-cache                      Do not use cache
     --clear-cache                   Empty the cache before fetching feed(s)
     --clear-readlist                Empty the saved readlist

--- a/informant/ui.py
+++ b/informant/ui.py
@@ -104,21 +104,24 @@ def pretty_print_item(entry):
     body = entry.body
     timestamp = str(entry.pretty_date)
     pager = InformantConfig().get_pager()
-    if not argv.get(RAW_OPT) and isinstance(pager, str) and shutil.which(pager) is not None:
-        body = format_body(body)
-        title = f"# {title}"
-        with os.popen(pager, 'w') as pipe:
-            pipe.write(format_content(entry, body, timestamp, title))
-        return 
-
+    pager_is_valid = isinstance(pager, str) and shutil.which(pager) is not None
     bold = InformantConfig().colors['BOLD']
     clear = InformantConfig().colors['CLEAR']
     if not argv.get(RAW_OPT):
-        #if not using raw also bold title
-        title = bold + title + clear
-        body = format_body(body)
-
-    print(format_content(entry, body, timestamp, title))
+        body = format_body(body)              
+        if pager_is_valid:
+            # format the title as a markdown header
+            # for a pager.
+            title = f"# {title}"
+        else:
+            #if not using raw also bold title
+            title = bold + title + clear         
+    
+    if pager_is_valid:
+        with os.popen(pager, 'w') as pipe:
+            pipe.write(format_content(entry, body, timestamp, title))
+    else:
+        print(format_content(entry, body, timestamp, title))
 
 def format_list_item(entry, index):
     """ Returns a formatted string with the entry's index number, title, and

--- a/informant/ui.py
+++ b/informant/ui.py
@@ -12,7 +12,7 @@ import textwrap
 import html2text
 import psutil
 
-from informant.config import InformantConfig
+from informant.config import PAGER_DEFAULT, InformantConfig
 
 RAW_OPT = '--raw'
 
@@ -80,6 +80,21 @@ def running_from_pacman():
     debug_print('informant running from: {}'.format(p_name))
     return p_name == 'pacman'
 
+def format_content(entry, body, timestamp, title) -> str:
+    if entry.feed_name is not None:
+        feed_name = '({})'.format(entry.feed_name)
+        content = '{}\n{}\n{}\n\n{}'.format(title, feed_name, timestamp, body)
+    else:
+        content = '{}\n{}\n\n{}'.format(title, timestamp, body)
+    return content
+
+def format_body(body) :
+    h2t = html2text.HTML2Text()
+    h2t.inline_links = False
+    h2t.body_width = 85
+    body = h2t.handle(body)
+    return body
+
 def pretty_print_item(entry):
     """ Print out the given entry, replacing some markup to make it look nicer.
     If the '--raw' option has been provided then the markup will not be
@@ -87,21 +102,23 @@ def pretty_print_item(entry):
     argv = InformantConfig().get_argv()
     title = entry.title
     body = entry.body
+    timestamp = str(entry.pretty_date)
+    pager = InformantConfig().get_pager()
+    if not argv.get(RAW_OPT) and isinstance(pager, str) and shutil.which(pager) is not None:
+        body = format_body(body)
+        title = f"# {title}"
+        with os.popen(pager, 'w') as pipe:
+            pipe.write(format_content(entry, body, timestamp, title))
+        return 
+
     bold = InformantConfig().colors['BOLD']
     clear = InformantConfig().colors['CLEAR']
-    timestamp = str(entry.pretty_date)
     if not argv.get(RAW_OPT):
         #if not using raw also bold title
         title = bold + title + clear
-        h2t = html2text.HTML2Text()
-        h2t.inline_links = False
-        h2t.body_width = 85
-        body = h2t.handle(body)
-    if entry.feed_name is not None:
-        feed_name = '({})'.format(entry.feed_name)
-        print('{}\n{}\n{}\n\n{}'.format(title, feed_name, timestamp, body))
-    else:
-        print('{}\n{}\n\n{}'.format(title, timestamp, body))
+        body = format_body(body)
+
+    print(format_content(entry, body, timestamp, title))
 
 def format_list_item(entry, index):
     """ Returns a formatted string with the entry's index number, title, and


### PR DESCRIPTION
Hi devs, thanks for this amazing tool!

This PR allows using an external pager to render the text. This adds a lot more possibilities to read/interact with the article:

* searching through the article;
* copying a command in the article to clipboard from within vim (with the help of [`vipe`](https://man.archlinux.org/man/extra/moreutils/vipe.1.en));
* sky is the limit...

I'm not quite sure what the best way to specify the pager is though. The current implementation gets the pager from the environment variable `INFORMANT_PAGER`, though I'm open to having an extra config option to specify the pager.

* Original implementation:
![image](https://github.com/user-attachments/assets/9bd73e28-8027-4d63-8a92-e6740d0356ed)

* Using `less`:
`export INFORMANT_PAGER=less`
![image](https://github.com/user-attachments/assets/2c9fab15-6cc2-4b59-b027-cfd5ed4faf22)
This allows scrolling over long news articles, articles, etc;

* Using [glow](https://github.com/charmbracelet/glow):
`export INFORMANT_PAGER=glow`
![image](https://github.com/user-attachments/assets/1db44bae-3bdc-4da9-b9d3-9a5a26b7201e)
This provides a variaty of syntax highlighting to improve readability.

Please let me know if anything needs to be changed (apart from the documentation, but that'll have to wait until we decide how the pager should be configured).